### PR TITLE
[CALCITE-3267] Remove method SqlDataTypeSpec#deriveType(RelDataTypefa…

### DIFF
--- a/core/src/main/java/org/apache/calcite/jdbc/ContextSqlValidator.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/ContextSqlValidator.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.jdbc;
+
+import org.apache.calcite.config.CalciteConnectionConfigImpl;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.validate.SqlConformanceEnum;
+import org.apache.calcite.sql.validate.SqlValidatorImpl;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.Properties;
+
+/**
+ * A SqlValidator with schema and type factory of the given
+ * {@link org.apache.calcite.jdbc.CalcitePrepare.Context}.
+ *
+ * <p>This class is only used to derive data type for DDL sql node.
+ * Usually we deduce query sql node data type(i.e. the {@code SqlSelect})
+ * during the validation phrase. DDL nodes don't have validation,
+ * they can be executed directly through
+ * {@link org.apache.calcite.sql.SqlExecutableStatement#execute(CalcitePrepare.Context)}.
+ * During the execution, {@link org.apache.calcite.sql.SqlDataTypeSpec} uses
+ * this validator to derive its type.
+ */
+public class ContextSqlValidator extends SqlValidatorImpl {
+
+  /**
+   * Create a {@code ContextSqlValidator}.
+   * @param context Prepare context.
+   * @param mutable Whether to get the mutable schema.
+   */
+  public ContextSqlValidator(CalcitePrepare.Context context, boolean mutable) {
+    super(SqlStdOperatorTable.instance(), getCatalogReader(context, mutable),
+        context.getTypeFactory(), SqlConformanceEnum.DEFAULT);
+  }
+
+  private static CalciteCatalogReader getCatalogReader(
+      CalcitePrepare.Context context, boolean mutable) {
+    return new CalciteCatalogReader(
+        mutable ? context.getMutableRootSchema() : context.getRootSchema(),
+        ImmutableList.of(),
+        context.getTypeFactory(),
+        new CalciteConnectionConfigImpl(new Properties()));
+  }
+}
+
+// End ContextSqlValidator.java

--- a/core/src/main/java/org/apache/calcite/sql/SqlBasicTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlBasicTypeNameSpec.java
@@ -186,10 +186,6 @@ public class SqlBasicTypeNameSpec extends SqlTypeNameSpec {
 
   @Override public RelDataType deriveType(SqlValidator validator) {
     final RelDataTypeFactory typeFactory = validator.getTypeFactory();
-    return deriveType(typeFactory);
-  }
-
-  @Override public RelDataType deriveType(RelDataTypeFactory typeFactory) {
     if (sqlTypeName == null) {
       return null;
     }

--- a/core/src/main/java/org/apache/calcite/sql/SqlCollectionTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlCollectionTypeNameSpec.java
@@ -76,14 +76,6 @@ public class SqlCollectionTypeNameSpec extends SqlTypeNameSpec {
     return elementTypeName;
   }
 
-  @Override public RelDataType deriveType(RelDataTypeFactory typeFactory) {
-    RelDataType type = elementTypeName.deriveType(typeFactory);
-    if (type == null) {
-      return null;
-    }
-    return createCollectionType(type, typeFactory);
-  }
-
   @Override public RelDataType deriveType(SqlValidator validator) {
     final RelDataType type = elementTypeName.deriveType(validator);
     return createCollectionType(type, validator.getTypeFactory());

--- a/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDataTypeSpec.java
@@ -213,42 +213,28 @@ public class SqlDataTypeSpec extends SqlNode {
   }
 
   /**
-   * Throws an error if the type is not found.
+   * Converts this type specification to a {@link RelDataType}.
+   *
+   * <p>Throws an error if the type is not found.
    */
   public RelDataType deriveType(SqlValidator validator) {
-    RelDataType type;
-    type = typeNameSpec.deriveType(validator);
-
-    // Fix-up the nullability, default is false.
-    final RelDataTypeFactory typeFactory = validator.getTypeFactory();
-    type = fixUpNullability(typeFactory, type, false);
-    return type;
-  }
-
-  /**
-   * Does not throw an error (returns null) if the type is not built-in.
-   */
-  public RelDataType deriveType(RelDataTypeFactory typeFactory) {
-    return deriveType(typeFactory, false);
+    return deriveType(validator, false);
   }
 
   /**
    * Converts this type specification to a {@link RelDataType}.
    *
-   * <p>Does not throw an error (returns null) if the type is not built-in.
+   * <p>Throws an error if the type is not found.
    *
    * @param nullable Whether the type is nullable if the type specification
-   *                 does not explicitly state
+   *                 does not explicitly state.
    */
-  public RelDataType deriveType(RelDataTypeFactory typeFactory,
-      boolean nullable) {
+  public RelDataType deriveType(SqlValidator validator, boolean nullable) {
     RelDataType type;
-    type = createTypeFromTypeNameSpec(typeFactory, typeNameSpec);
-    if (type == null) {
-      // This is definitely not a builtin data type, returns null.
-      return null;
-    }
+    type = typeNameSpec.deriveType(validator);
 
+    // Fix-up the nullability, default is false.
+    final RelDataTypeFactory typeFactory = validator.getTypeFactory();
     type = fixUpNullability(typeFactory, type, nullable);
     return type;
   }
@@ -269,17 +255,6 @@ public class SqlDataTypeSpec extends SqlNode {
       nullable = this.nullable;
     }
     return typeFactory.createTypeWithNullability(type, nullable);
-  }
-
-  /**
-   * Create type from the type name specification directly.
-   * @param typeFactory type factory.
-   * @return the type.
-   */
-  private RelDataType createTypeFromTypeNameSpec(
-      RelDataTypeFactory typeFactory,
-      SqlTypeNameSpec typeNameSpec) {
-    return typeNameSpec.deriveType(typeFactory);
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlRowTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlRowTypeNameSpec.java
@@ -123,16 +123,6 @@ public class SqlRowTypeNameSpec extends SqlTypeNameSpec {
     return litmus.succeed();
   }
 
-  @Override public RelDataType deriveType(RelDataTypeFactory typeFactory) {
-    return typeFactory.createStructType(
-        fieldTypes.stream()
-            .map(dt -> dt.deriveType(typeFactory))
-            .collect(Collectors.toList()),
-        fieldNames.stream()
-            .map(SqlIdentifier::toString)
-            .collect(Collectors.toList()));
-  }
-
   @Override public RelDataType deriveType(SqlValidator sqlValidator) {
     final RelDataTypeFactory typeFactory = sqlValidator.getTypeFactory();
     return typeFactory.createStructType(

--- a/core/src/main/java/org/apache/calcite/sql/SqlTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlTypeNameSpec.java
@@ -17,7 +17,6 @@
 package org.apache.calcite.sql;
 
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.Litmus;
@@ -29,7 +28,7 @@ import org.apache.calcite.util.Litmus;
  * <p>To customize sql node unparsing, override the method
  * {@link #unparse(SqlWriter, int, int)}.
  * <p>To customize data type deriving, override the method
- * {@link #deriveType(RelDataTypeFactory)}.
+ * {@link #deriveType(SqlValidator)}.
  */
 public abstract class SqlTypeNameSpec {
   private final SqlIdentifier typeName;
@@ -45,15 +44,6 @@ public abstract class SqlTypeNameSpec {
     this.typeName = name;
     this.pos = pos;
   }
-
-  /**
-   * Derive type from this SqlTypeNameSpec.
-   *
-   * @param typeFactory Type factory.
-   * @return the {@code RelDataType} instance, or null if the SqlTypeNameSpec is not a
-   *         builtin sql type name.
-   */
-  public abstract RelDataType deriveType(RelDataTypeFactory typeFactory);
 
   /**
    * Derive type from this SqlTypeNameSpec.

--- a/core/src/main/java/org/apache/calcite/sql/SqlUserDefinedTypeNameSpec.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUserDefinedTypeNameSpec.java
@@ -17,7 +17,6 @@
 package org.apache.calcite.sql;
 
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.util.Litmus;
@@ -42,11 +41,6 @@ public class SqlUserDefinedTypeNameSpec extends SqlTypeNameSpec {
     super(typeName, pos);
   }
 
-  @Override public RelDataType deriveType(RelDataTypeFactory typeFactory) {
-    // Returns null to let the SqlValidator deduce the type.
-    return null;
-  }
-
   public SqlUserDefinedTypeNameSpec(String name, SqlParserPos pos) {
     this(new SqlIdentifier(name, pos), pos);
   }
@@ -58,7 +52,7 @@ public class SqlUserDefinedTypeNameSpec extends SqlTypeNameSpec {
   }
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
-    final String name = getTypeName().getSimple();
+    final String name = getTypeName().names.get(0);
     if (name.startsWith("_")) {
       // We're generating a type for an alien system. For example,
       // UNSIGNED is a built-in type in MySQL.

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorUtil.java
@@ -107,10 +107,9 @@ public class SqlValidatorUtil {
       if (resolvedNamespace.isWrapperFor(TableNamespace.class)) {
         final TableNamespace tableNamespace = resolvedNamespace.unwrap(TableNamespace.class);
         final SqlValidatorTable validatorTable = tableNamespace.getTable();
-        final RelDataTypeFactory typeFactory = catalogReader.getTypeFactory();
         final List<RelDataTypeField> extendedFields = dmlNamespace.extendList == null
             ? ImmutableList.of()
-            : getExtendedColumns(typeFactory, validatorTable, dmlNamespace.extendList);
+            : getExtendedColumns(namespace.getValidator(), validatorTable, dmlNamespace.extendList);
         return getRelOptTable(
             tableNamespace, catalogReader, datasetName, usedDataset, extendedFields);
       }
@@ -145,7 +144,7 @@ public class SqlValidatorUtil {
    * Gets a list of extended columns with field indices to the underlying table.
    */
   public static List<RelDataTypeField> getExtendedColumns(
-      RelDataTypeFactory typeFactory, SqlValidatorTable table, SqlNodeList extendedColumns) {
+      SqlValidator validator, SqlValidatorTable table, SqlNodeList extendedColumns) {
     final ImmutableList.Builder<RelDataTypeField> extendedFields =
         ImmutableList.builder();
     final ExtensibleTable extTable = table.unwrap(ExtensibleTable.class);
@@ -159,7 +158,7 @@ public class SqlValidatorUtil {
       extendedFields.add(
           new RelDataTypeFieldImpl(identifier.toString(),
               extendedFieldOffset++,
-              type.deriveType(typeFactory)));
+              type.deriveType(validator)));
     }
     return extendedFields.build();
   }

--- a/core/src/main/java/org/apache/calcite/sql/validate/TableNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/TableNamespace.java
@@ -93,12 +93,11 @@ class TableNamespace extends AbstractNamespace {
         ImmutableList.builder();
     builder.addAll(this.extendedFields);
     builder.addAll(
-        SqlValidatorUtil.getExtendedColumns(validator.getTypeFactory(),
+        SqlValidatorUtil.getExtendedColumns(validator,
             getTable(), extendList));
     final List<RelDataTypeField> extendedFields = builder.build();
     final Table schemaTable = table.unwrap(Table.class);
-    if (schemaTable != null
-        && table instanceof RelOptTable
+    if (table instanceof RelOptTable
         && (schemaTable instanceof ExtensibleTable
           || schemaTable instanceof ModifiableViewTable)) {
       checkExtendedColumnTypes(extendList);
@@ -132,8 +131,7 @@ class TableNamespace extends AbstractNamespace {
    */
   private void checkExtendedColumnTypes(SqlNodeList extendList) {
     final List<RelDataTypeField> extendedFields =
-        SqlValidatorUtil.getExtendedColumns(
-            validator.getTypeFactory(), table, extendList);
+        SqlValidatorUtil.getExtendedColumns(validator, table, extendList);
     final List<RelDataTypeField> baseFields =
         getBaseRowType().getFieldList();
     final Map<String, Integer> nameToIndex =

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -2337,7 +2337,7 @@ public class SqlToRelConverter {
       final SqlValidatorTable validatorTable =
           table.unwrap(SqlValidatorTable.class);
       final List<RelDataTypeField> extendedFields =
-          SqlValidatorUtil.getExtendedColumns(validator.getTypeFactory(), validatorTable,
+          SqlValidatorUtil.getExtendedColumns(validator, validatorTable,
               extendedColumns);
       table = table.extend(extendedFields);
     }

--- a/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/StandardConvertletTable.java
@@ -515,7 +515,7 @@ public class StandardConvertletTable extends ReflectiveConvertletTable {
       return castToValidatedType(cx, call, cx.convertExpression(left));
     }
     SqlDataTypeSpec dataType = (SqlDataTypeSpec) right;
-    RelDataType type = dataType.deriveType(typeFactory);
+    RelDataType type = dataType.deriveType(cx.getValidator());
     if (type == null) {
       type = cx.getValidator().getValidatedNodeType(dataType.getTypeName());
     }

--- a/core/src/test/java/org/apache/calcite/sql/parser/parserextensiontesting/SqlCreateTable.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/parserextensiontesting/SqlCreateTable.java
@@ -19,7 +19,7 @@ package org.apache.calcite.sql.parser.parserextensiontesting;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.jdbc.CalciteSchema;
-import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.jdbc.ContextSqlValidator;
 import org.apache.calcite.linq4j.Enumerator;
 import org.apache.calcite.linq4j.Linq4j;
 import org.apache.calcite.linq4j.QueryProvider;
@@ -43,6 +43,7 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.test.JdbcTest;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
@@ -108,11 +109,12 @@ public class SqlCreateTable extends SqlCreate
     for (String p : path) {
       schema = schema.getSubSchema(p, true);
     }
-    final JavaTypeFactory typeFactory = new JavaTypeFactoryImpl();
+    final JavaTypeFactory typeFactory = context.getTypeFactory();
     final RelDataTypeFactory.Builder builder = typeFactory.builder();
+    final SqlValidator validator = new ContextSqlValidator(context, false);
     for (Pair<SqlIdentifier, SqlDataTypeSpec> pair : nameTypes()) {
       builder.add(pair.left.getSimple(),
-          pair.right.deriveType(typeFactory, true));
+          pair.right.deriveType(validator, true));
     }
     final RelDataType rowType = builder.build();
     schema.add(name.getSimple(),

--- a/server/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
+++ b/server/src/main/java/org/apache/calcite/sql/ddl/SqlCreateTable.java
@@ -19,7 +19,6 @@ package org.apache.calcite.sql.ddl;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.jdbc.CalciteSchema;
-import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.linq4j.Enumerator;
 import org.apache.calcite.linq4j.Linq4j;
 import org.apache.calcite.linq4j.Ord;
@@ -60,6 +59,7 @@ import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.InitializerContext;
 import org.apache.calcite.sql2rel.InitializerExpressionFactory;
 import org.apache.calcite.sql2rel.NullInitializerExpressionFactory;
@@ -127,7 +127,7 @@ public class SqlCreateTable extends SqlCreate
   public void execute(CalcitePrepare.Context context) {
     final Pair<CalciteSchema, String> pair =
         SqlDdlNodes.schema(context, true, name);
-    final JavaTypeFactory typeFactory = new JavaTypeFactoryImpl();
+    final JavaTypeFactory typeFactory = context.getTypeFactory();
     final RelDataType queryRowType;
     if (query != null) {
       // A bit of a hack: pretend it's a view, to get its row type
@@ -164,22 +164,13 @@ public class SqlCreateTable extends SqlCreate
     final ImmutableList.Builder<ColumnDef> b = ImmutableList.builder();
     final RelDataTypeFactory.Builder builder = typeFactory.builder();
     final RelDataTypeFactory.Builder storedBuilder = typeFactory.builder();
+    // REVIEW 2019-08-19 Danny Chan: Should we implement the #validate(SqlValidator)
+    // to get the SqlValidator instance ?
+    final SqlValidator validator = SqlDdlNodes.validator(context, true);
     for (Ord<SqlNode> c : Ord.zip(columnList)) {
       if (c.e instanceof SqlColumnDeclaration) {
         final SqlColumnDeclaration d = (SqlColumnDeclaration) c.e;
-        RelDataType type = d.dataType.deriveType(typeFactory, true);
-        final Pair<CalciteSchema, String> pairForType =
-            SqlDdlNodes.schema(context, true, d.dataType.getTypeName());
-        if (type == null) {
-          CalciteSchema.TypeEntry typeEntry = pairForType.left.getType(pairForType.right, false);
-          if (typeEntry != null) {
-            type = typeEntry.getType().apply(typeFactory);
-            if (d.dataType.getNullable() != null
-                    && d.dataType.getNullable() != type.isNullable()) {
-              type = typeFactory.createTypeWithNullability(type, d.dataType.getNullable());
-            }
-          }
-        }
+        final RelDataType type = d.dataType.deriveType(validator, true);
         builder.add(d.name.getSimple(), type);
         if (d.strategy != ColumnStrategy.VIRTUAL) {
           storedBuilder.add(d.name.getSimple(), type);

--- a/server/src/main/java/org/apache/calcite/sql/ddl/SqlDdlNodes.java
+++ b/server/src/main/java/org/apache/calcite/sql/ddl/SqlDdlNodes.java
@@ -18,6 +18,7 @@ package org.apache.calcite.sql.ddl;
 
 import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.jdbc.ContextSqlValidator;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.schema.ColumnStrategy;
 import org.apache.calcite.sql.SqlCall;
@@ -34,6 +35,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.pretty.SqlPrettyWriter;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
@@ -195,6 +197,14 @@ public class SqlDdlNodes {
       schema = schema.getSubSchema(p, true);
     }
     return Pair.of(schema, name);
+  }
+
+  /**
+   * Returns the SqlValidator with the given {@code context} schema
+   * and type factory.
+   * */
+  static SqlValidator validator(CalcitePrepare.Context context, boolean mutable) {
+    return new ContextSqlValidator(context, mutable);
   }
 
   /** Wraps a query to rename its columns. Used by CREATE VIEW and CREATE

--- a/server/src/test/java/org/apache/calcite/test/ServerParserTest.java
+++ b/server/src/test/java/org/apache/calcite/test/ServerParserTest.java
@@ -161,6 +161,18 @@ public class ServerParserTest extends SqlParserTest {
     sql(sql).ok(expected);
   }
 
+  @Test public void testCreateTableWithUDT() {
+    final String sql = "create table if not exists t (\n"
+        + "  f0 MyType0 not null,\n"
+        + "  f1 db_name.MyType1,\n"
+        + "  f2 catalog_name.db_name.MyType2)";
+    final String expected = "CREATE TABLE IF NOT EXISTS `T` ("
+        + "`F0` `MYTYPE0` NOT NULL,"
+        + " `F1` `DB_NAME`.`MYTYPE1`,"
+        + " `F2` `CATALOG_NAME`.`DB_NAME`.`MYTYPE2`)";
+    sql(sql).ok(expected);
+  }
+
   @Test public void testCreateView() {
     final String sql = "create or replace view v as\n"
         + "select * from (values (1, '2'), (3, '45')) as t (x, y)";

--- a/server/src/test/java/org/apache/calcite/test/ServerTest.java
+++ b/server/src/test/java/org/apache/calcite/test/ServerTest.java
@@ -151,6 +151,18 @@ public class ServerTest {
       assertThat(b, is(false));
       x = s.executeUpdate("insert into w values (1, NULL)");
       assertThat(x, is(1));
+
+      // Test user defined type name as component identifier.
+      b = s.execute("create schema a");
+      assertThat(b, is(false));
+      b = s.execute("create schema a.b");
+      assertThat(b, is(false));
+      b = s.execute("create type a.b.mytype as (i varchar(5))");
+      assertThat(b, is(false));
+      b = s.execute("create table t2 (i int not null, j a.b.mytype)");
+      assertThat(b, is(false));
+      x = s.executeUpdate("insert into t2 values (1, NULL)");
+      assertThat(x, is(1));
     }
   }
 


### PR DESCRIPTION
…ctory)

Changes:
* Remove method SqlDataTypeSpec#deriveType(RelDataTypefactory);
* Add a SqlValidator subType ContextSqlValidator used to derive type during DDL
nodes execution;
* Support create table with user defined type and add test case.